### PR TITLE
use seagullua\NameCaseLib\NCLNameCaseRu in NCLNameCaseCore

### DIFF
--- a/Library/NCL/NCLNameCaseCore.php
+++ b/Library/NCL/NCLNameCaseCore.php
@@ -1,6 +1,8 @@
 <?php
 namespace seagullua\NameCaseLib\NCL;
 
+use seagullua\NameCaseLib\NCLNameCaseRu;
+
 /**
  * @license Dual licensed under the MIT or GPL Version 2 licenses.
  * @package NameCaseLib


### PR DESCRIPTION
Исправлена ошибка Error: Class 'seagullua\NameCaseLib\NCL\NCLNameCaseRu' not found in /var/www/html/my_project/vendor/nazbav/name-case-lib/Library/NCL/NCLNameCaseCore.php:642